### PR TITLE
Fix search string used to determine if hash was found

### DIFF
--- a/Core/core.c
+++ b/Core/core.c
@@ -80,11 +80,11 @@ short hashScan_md5(char *filename){
       char *name;
 
       extractString(page->data , "<title>","</title>", &name);
-      if(extractString == 0){
+      if(name == NULL){
             puts("Hash is not in threatexpert db.");
       }
       else{
-            if( strstr(name,"ThreatExpert Reports:") == NULL )
+            if( strstr(name,"ThreatExpert Report:") == NULL )
                   puts("Hash is not in threatexpert db.");
             else
                   printf("\t[%s]\n",name);

--- a/hashScan.c
+++ b/hashScan.c
@@ -6,7 +6,7 @@
 #include "Core/core.h"
 #include "control/control.h"
 
-#define VERSION "1.0"
+#define VERSION "1.0.1"
 
 int main(int argc , char **argv){
       if(argc == 1)


### PR DESCRIPTION
This pull request fixes the following:
- Compiler Error
- Incorrect search string for determining if the hash was found

Successfully tested using live malware obtained from [tekdefence.com](http://www.tekdefense.com/downloads/malware-samples/), `tekdefense.zip`

```
$ ./hashScan TekDefense.exe
hashScan Version 1.0
    md5 Hash: [ 1d8b370a114f9490f36bebd77ed347d1 ]
    [ThreatExpert Report: NetCat, not-a-virus:RemoteAdmin.Win32.NetCat.alj, Trojan.SuspectCRC, Hacktool.]
```
###### Compiler Error

```
clang -g hashScan.c md5/md5.c Core/core.c Strings/Strings.c Networking/Networking.c control/control.c -o hashScan -lcrypto -Wall -Werror -lcurl
Core/core.c:83:10: error: comparison of function 'extractString' equal to a null
      pointer is always false [-Werror,-Wtautological-pointer-compare]
      if(extractString == 0){
         ^~~~~~~~~~~~~    ~
Core/core.c:83:10: note: prefix with the address-of operator to silence this
      warning
      if(extractString == 0){
         ^
         &
1 error generated.
make: *** [compile] Error 1
```
